### PR TITLE
test: pin asyncapi/cli image to 1.7.3

### DIFF
--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -14,7 +14,7 @@ services:
       - ../../wazo_bus:/app/wazo_bus:ro
 
   spec-validator:
-    image: asyncapi/cli:latest
+    image: asyncapi/cli:1.7.3  # FIXME: revert to latest when 1.9.0 will be released
 
   rabbitmq:
     profiles:


### PR DESCRIPTION
why: because 1.8.0 introduce a new POC feature that create conflict.
However, a fix seems available in 1.9.0, but docker image is not built
for this version ...