### PR TITLE
Pull request for unpin-asyncapi-cli

### DIFF
--- a/integration_tests/assets/docker-compose.documentation.override.yml
+++ b/integration_tests/assets/docker-compose.documentation.override.yml
@@ -14,7 +14,7 @@ services:
       - ../../wazo_bus:/app/wazo_bus:ro
 
   spec-validator:
-    image: asyncapi/cli:1.7.3  # FIXME: revert to latest when 1.9.0 will be released
+    image: asyncapi/cli
 
   rabbitmq:
     profiles:

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -61,7 +61,14 @@ class TestDocumentation(AbstractAssetLaunchingHelper, TestCase):
         options = cls._docker_compose_options()
         volumes = ['-v', f'{path}:/{name}.yml']
         service = [cls.validator]
-        service_args = ['validate', '--diagnostics-format', 'json', f'/{name}.yml']
+        service_args = [
+            'validate',
+            '--fail-severity',
+            'error',
+            '--diagnostics-format',
+            'json',
+            f'/{name}.yml',
+        ]
 
         args = _DOCKER_RUN_COMMAND + volumes + service + service_args
         return _run_cmd(program + options + args)
@@ -71,7 +78,6 @@ class TestDocumentation(AbstractAssetLaunchingHelper, TestCase):
         output = process.stdout.decode().split('\n')
         starting_json = output.index('[')
         issues = json.loads(''.join(output[starting_json:]))
-
         return [issue['message'] for issue in issues if issue['severity'] == 0]
 
     def test_documentation_is_valid(self):
@@ -90,11 +96,7 @@ class TestDocumentation(AbstractAssetLaunchingHelper, TestCase):
                     result = self._validate_specfile(name, path)
 
                     if result.returncode != 0:
-                        print(result.stdout.decode())
-                        raise DockerError('Failed to run AsyncAPI validator')
-
-                    if errors := self._parse_errors(result):
-                        for error in errors:
+                        for error in self._parse_errors(result):
                             print(error)
                         raise ValidationError(
                             f'Validation failed for {name} specification file'

--- a/integration_tests/suite/test_documentation.py
+++ b/integration_tests/suite/test_documentation.py
@@ -69,7 +69,8 @@ class TestDocumentation(AbstractAssetLaunchingHelper, TestCase):
     @classmethod
     def _parse_errors(cls, process: subprocess.CompletedProcess) -> list[str]:
         output = process.stdout.decode().split('\n')
-        issues = json.loads(''.join(output[2:]))
+        starting_json = output.index('[')
+        issues = json.loads(''.join(output[starting_json:]))
 
         return [issue['message'] for issue in issues if issue['severity'] == 0]
 


### PR DESCRIPTION
## unpin asyncapi/cli image

why: new version 1.9.2 has been released

## test: fix usage of asyncapicli when error

why: previous container images have a bug that returncode was always 0
(whatever was the value of --fail-severity).
Now this bug is fixed, we can use the returncode to make logic