### PR TITLE
WAZO-3740: Fix parking events ACLs

### DIFF
--- a/wazo_bus/resources/calls/parking.py
+++ b/wazo_bus/resources/calls/parking.py
@@ -18,6 +18,7 @@ class CallParkedEvent(TenantEvent):
         call_id: str,
         parking_id: int,
         slot: str,
+        parked_at: str,
         timeout_at: str | None,
         tenant_uuid: UUIDStr,
     ):
@@ -25,6 +26,7 @@ class CallParkedEvent(TenantEvent):
             'call_id': call_id,
             'parking_id': parking_id,
             'slot': slot,
+            'parked_at': parked_at,
             'timeout_at': timeout_at,
         }
         super().__init__(content, tenant_uuid)
@@ -41,6 +43,7 @@ class CallUnparkedEvent(TenantEvent):
         call_id: str,
         parking_id: int,
         slot: str,
+        parked_since: str,
         retriever_call_id: str,
         tenant_uuid: UUIDStr,
     ):
@@ -48,6 +51,7 @@ class CallUnparkedEvent(TenantEvent):
             'call_id': call_id,
             'parking_id': parking_id,
             'slot': slot,
+            'parked_since': parked_since,
             'retriever_call_id': retriever_call_id,
         }
         super().__init__(content, tenant_uuid)

--- a/wazo_bus/resources/calls/parking.py
+++ b/wazo_bus/resources/calls/parking.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from ..common.event import TenantEvent
 from ..common.types import UUIDStr
+from .types import ParkedCallDict, ParkedCallTimedOutDict, UnparkedCallDict
 
 
 class CallParkedEvent(TenantEvent):
@@ -13,23 +14,8 @@ class CallParkedEvent(TenantEvent):
     routing_key_fmt = 'parkings.{parking_id}.calls.updated'
     required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
-    def __init__(
-        self,
-        call_id: str,
-        parking_id: int,
-        slot: str,
-        parked_at: str,
-        timeout_at: str | None,
-        tenant_uuid: UUIDStr,
-    ):
-        content = {
-            'call_id': call_id,
-            'parking_id': parking_id,
-            'slot': slot,
-            'parked_at': parked_at,
-            'timeout_at': timeout_at,
-        }
-        super().__init__(content, tenant_uuid)
+    def __init__(self, parked_call: ParkedCallDict, tenant_uuid: UUIDStr):
+        super().__init__(parked_call, tenant_uuid)
 
 
 class CallUnparkedEvent(TenantEvent):
@@ -38,23 +24,8 @@ class CallUnparkedEvent(TenantEvent):
     routing_key_fmt = 'parkings.{parking_id}.calls.updated'
     required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
-    def __init__(
-        self,
-        call_id: str,
-        parking_id: int,
-        slot: str,
-        parked_since: str,
-        retriever_call_id: str,
-        tenant_uuid: UUIDStr,
-    ):
-        content = {
-            'call_id': call_id,
-            'parking_id': parking_id,
-            'slot': slot,
-            'parked_since': parked_since,
-            'retriever_call_id': retriever_call_id,
-        }
-        super().__init__(content, tenant_uuid)
+    def __init__(self, unparked_call: UnparkedCallDict, tenant_uuid: str):
+        super().__init__(unparked_call, tenant_uuid)
 
 
 class ParkedCallHungupEvent(TenantEvent):
@@ -63,21 +34,8 @@ class ParkedCallHungupEvent(TenantEvent):
     routing_key_fmt = 'parkings.{parking_id}.calls.updated'
     required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
-    def __init__(
-        self,
-        call_id: str,
-        parking_id: int,
-        slot: str,
-        parked_since: str,
-        tenant_uuid: UUIDStr,
-    ):
-        content = {
-            'call_id': call_id,
-            'parking_id': parking_id,
-            'slot': slot,
-            'parked_since': parked_since,
-        }
-        super().__init__(content, tenant_uuid)
+    def __init__(self, parked_call: ParkedCallDict, tenant_uuid: str):
+        super().__init__(parked_call, tenant_uuid)
 
 
 class ParkedCallTimedOutEvent(TenantEvent):
@@ -86,18 +44,5 @@ class ParkedCallTimedOutEvent(TenantEvent):
     routing_key_fmt = 'parkings.{parking_id}.calls.updated'
     required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
-    def __init__(
-        self,
-        call_id: str,
-        parking_id: int,
-        dialed_extension: str | None,
-        parked_since: str,
-        tenant_uuid: UUIDStr,
-    ):
-        content = {
-            'call_id': call_id,
-            'parking_id': parking_id,
-            'dialed_extension': dialed_extension,
-            'parked_since': parked_since,
-        }
-        super().__init__(content, tenant_uuid)
+    def __init__(self, parked_call: ParkedCallTimedOutDict, tenant_uuid: str):
+        super().__init__(parked_call, tenant_uuid)

--- a/wazo_bus/resources/calls/parking.py
+++ b/wazo_bus/resources/calls/parking.py
@@ -10,8 +10,8 @@ from ..common.types import UUIDStr
 class CallParkedEvent(TenantEvent):
     service = 'calld'
     name = 'call_parked'
-    routing_key_fmt = 'calls.park.created'
-    required_acl_fmt = 'events.calls.{call_id}'
+    routing_key_fmt = 'parkings.{parking_id}.calls.updated'
+    required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
     def __init__(
         self,
@@ -35,8 +35,8 @@ class CallParkedEvent(TenantEvent):
 class CallUnparkedEvent(TenantEvent):
     service = 'calld'
     name = 'call_unparked'
-    routing_key_fmt = 'calls.park.deleted'
-    required_acl_fmt = 'events.calls.{call_id}'
+    routing_key_fmt = 'parkings.{parking_id}.calls.updated'
+    required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
     def __init__(
         self,
@@ -60,8 +60,8 @@ class CallUnparkedEvent(TenantEvent):
 class ParkedCallHungupEvent(TenantEvent):
     service = 'calld'
     name = 'parked_call_hungup'
-    routing_key_fmt = 'calls.park.deleted'
-    required_acl_fmt = 'events.calls.{call_id}'
+    routing_key_fmt = 'parkings.{parking_id}.calls.updated'
+    required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
     def __init__(
         self,
@@ -83,8 +83,8 @@ class ParkedCallHungupEvent(TenantEvent):
 class ParkedCallTimedOutEvent(TenantEvent):
     service = 'calld'
     name = 'parked_call_timed_out'
-    routing_key_fmt = 'calls.park.deleted'
-    required_acl_fmt = 'events.calls.{call_id}'
+    routing_key_fmt = 'parkings.{parking_id}.calls.updated'
+    required_acl_fmt = 'events.parkings.{parking_id}.calls.updated'
 
     def __init__(
         self,

--- a/wazo_bus/resources/calls/types.py
+++ b/wazo_bus/resources/calls/types.py
@@ -87,6 +87,8 @@ class ParkedCallDict(TypedDict, total=False):
 
 class UnparkedCallDict(ParkedCallDict, total=False):
     retriever_call_id: str
+    retriever_caller_id_name: str
+    retriever_caller_id_num: str
 
 
 class ParkedCallTimedOutDict(ParkedCallDict, total=False):

--- a/wazo_bus/resources/calls/types.py
+++ b/wazo_bus/resources/calls/types.py
@@ -72,6 +72,27 @@ class CallDict(TypedDict, total=False):
     direction: str
 
 
+class ParkedCallDict(TypedDict, total=False):
+    parking_id: int
+    call_id: str
+    conversation_id: str
+    caller_id_name: str
+    caller_id_num: str
+    parker_caller_id_name: str
+    parker_caller_id_num: str
+    slot: str
+    parked_at: DateTimeStr
+    timeout_at: DateTimeStr | None
+
+
+class UnparkedCallDict(ParkedCallDict, total=False):
+    retriever_call_id: str
+
+
+class ParkedCallTimedOutDict(ParkedCallDict, total=False):
+    dialed_extension: str
+
+
 class RelocateDict(TypedDict, total=False):
     uuid: UUIDStr
     relocated_call: str


### PR DESCRIPTION
This PR fixes the ACL used by the parking events (with changes in wazo-auth-keys) and should allow a user to receive the parking events through the websocket

Changes: 
- Fix ACL on parking events
- Add parker information on parked call event
- Add retriever information on unparked call event
- Refactor of parking events 