### PR TITLE
Pull request for WAZO-3648-dedicated-exchange

### DIFF
--- a/wazo_bus/base.py
+++ b/wazo_bus/base.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -25,7 +25,7 @@ class BaseProtocol(Protocol):
     _name: str
     _logger: logging.Logger
     _connection_params: ConnectionParams
-    _default_exchange: Exchange
+    _exchange: Exchange
 
     def __init__(
         self,
@@ -90,14 +90,16 @@ class Base(BaseProtocol):
         port: int = 5672,
         exchange_name: str = '',
         exchange_type: str = '',
+        exchange_durable: bool = True,
         **kwargs: Any,
     ) -> None:
-        durable = kwargs.pop('exchange_durable', True)
         self._name = name or type(self).__name__
         self._logger = logging.getLogger(type(self).__name__)
         self._connection_params = ConnectionParams(username, password, host, port)
-        self._default_exchange = Exchange(
-            name=exchange_name, type=exchange_type, durable=durable
+        self._exchange = Exchange(
+            name=exchange_name,
+            type=exchange_type,
+            durable=exchange_durable,
         )
 
     @property

--- a/wazo_bus/base.py
+++ b/wazo_bus/base.py
@@ -91,6 +91,7 @@ class Base(BaseProtocol):
         exchange_name: str = '',
         exchange_type: str = '',
         exchange_durable: bool = True,
+        exchange_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         self._name = name or type(self).__name__
@@ -100,6 +101,7 @@ class Base(BaseProtocol):
             name=exchange_name,
             type=exchange_type,
             durable=exchange_durable,
+            **(exchange_kwargs or {}),
         )
 
     @property

--- a/wazo_bus/consumer.py
+++ b/wazo_bus/consumer.py
@@ -19,6 +19,7 @@ class BusConsumer(WazoEventMixin, ThreadableMixin, ConsumerMixin, Base):
         port: int = 5672,
         exchange_name: str = '',
         exchange_type: str = '',
+        exchange_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -29,5 +30,6 @@ class BusConsumer(WazoEventMixin, ThreadableMixin, ConsumerMixin, Base):
             port=port,
             exchange_name=exchange_name,
             exchange_type=exchange_type,
+            exchange_kwargs=exchange_kwargs,
             **kwargs,
         )

--- a/wazo_bus/consumer.py
+++ b/wazo_bus/consumer.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2020-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,12 +6,7 @@ from __future__ import annotations
 from typing import Any
 
 from .base import Base
-from .mixins import (
-    ConsumerMixin,
-    SubscribeExchangeDict,
-    ThreadableMixin,
-    WazoEventMixin,
-)
+from .mixins import ConsumerMixin, ThreadableMixin, WazoEventMixin
 
 
 class BusConsumer(WazoEventMixin, ThreadableMixin, ConsumerMixin, Base):
@@ -24,7 +19,6 @@ class BusConsumer(WazoEventMixin, ThreadableMixin, ConsumerMixin, Base):
         port: int = 5672,
         exchange_name: str = '',
         exchange_type: str = '',
-        subscribe: SubscribeExchangeDict | None = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -35,6 +29,5 @@ class BusConsumer(WazoEventMixin, ThreadableMixin, ConsumerMixin, Base):
             port=port,
             exchange_name=exchange_name,
             exchange_type=exchange_type,
-            subscribe=subscribe,
             **kwargs,
         )

--- a/wazo_bus/publisher.py
+++ b/wazo_bus/publisher.py
@@ -1,4 +1,4 @@
-# Copyright 2012-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2012-2025 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -23,6 +23,7 @@ class BusPublisher(WazoEventMixin, PublisherMixin, Base):
         port: int = 5672,
         exchange_name: str = '',
         exchange_type: str = '',
+        exchange_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -34,6 +35,7 @@ class BusPublisher(WazoEventMixin, PublisherMixin, Base):
             port=port,
             exchange_name=exchange_name,
             exchange_type=exchange_type,
+            exchange_kwargs=exchange_kwargs,
             **kwargs,
         )
 
@@ -55,6 +57,7 @@ class BusPublisherWithQueue(
         port: int = 5672,
         exchange_name: str = '',
         exchange_type: str = '',
+        exchange_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -66,5 +69,6 @@ class BusPublisherWithQueue(
             port=port,
             exchange_name=exchange_name,
             exchange_type=exchange_type,
+            exchange_kwargs=exchange_kwargs,
             **kwargs,
         )


### PR DESCRIPTION
## base/mixins: remove override for exchange

Why:

* exchange configuration in one place

## base/consumer/publisher: allow arbitrary exchange args

Why:

* Allows for auto-delete exchanges