### PR TITLE
TASK-101: Add transcription completed event

### DIFF
--- a/wazo_bus/resources/voicemail_transcription/event.py
+++ b/wazo_bus/resources/voicemail_transcription/event.py
@@ -1,0 +1,21 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from ..common.event import TenantEvent
+from ..common.types import UUIDStr
+from .types import TranscriptionCompletedPayload
+
+
+class VoicemailTranscriptionCompletedEvent(TenantEvent):
+    service = 'webhookd'
+    name = 'voicemail_transcription_completed'
+    routing_key_fmt = 'voicemails.transcriptions.completed'
+
+    def __init__(
+        self,
+        transcription: TranscriptionCompletedPayload,
+        tenant_uuid: UUIDStr,
+    ):
+        super().__init__(transcription, tenant_uuid)

--- a/wazo_bus/resources/voicemail_transcription/types.py
+++ b/wazo_bus/resources/voicemail_transcription/types.py
@@ -1,0 +1,19 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+from ..common.types import DateTimeStr, UUIDStr
+
+
+class TranscriptionCompletedPayload(TypedDict, total=False):
+    message_id: str
+    tenant_uuid: UUIDStr
+    voicemail_id: int
+    transcription_text: str
+    provider_id: str
+    language: str
+    duration: float
+    completed_at: DateTimeStr


### PR DESCRIPTION
TASK-101

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new event definition and payload typing without changing existing event dispatch logic.
> 
> **Overview**
> Introduces a new tenant-scoped event, `VoicemailTranscriptionCompletedEvent`, published with routing key `voicemails.transcriptions.completed` for consumers (service `webhookd`).
> 
> Adds `TranscriptionCompletedPayload` (a `TypedDict`) to standardize the emitted payload fields for completed voicemail transcriptions (e.g., voicemail/message IDs, text, provider/language, duration, timestamp).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f578108467e0ec6d2df7b818149d94dcbf88cf60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->