### PR TITLE
pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       TARGETS: "rabbitmq:5672 bus:5000"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - "5672"
     volumes:


### PR DESCRIPTION
Why: exclusive queue changes break everything. bookworm uses 3.10.8 so that's ok for now

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only Docker Compose change that just constrains the RabbitMQ image version, with no production code impact.
> 
> **Overview**
> Pins the `integration_tests/assets/docker-compose.yml` RabbitMQ service from `rabbitmq` (latest) to `rabbitmq:3` to keep integration tests running against the v3 broker behavior and avoid breakage from newer RabbitMQ releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c5a8010d2b4c458c924eb7722d15b8821b007d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->