### PR TITLE
chatd: identity and delivery status events for connectors plugin

### DIFF
--- a/wazo_bus/resources/chatd/events.py
+++ b/wazo_bus/resources/chatd/events.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from ..common.event import MultiUserEvent, TenantEvent, UserEvent
+from ..common.event import TenantEvent, UserEvent
 from ..common.types import UUIDStr
 from .types import (
     DeliveryStatusDict,
@@ -101,10 +101,11 @@ class UserIdentityDeletedEvent(UserEvent):
         super().__init__(identity_data, tenant_uuid, user_uuid)
 
 
-class MessageDeliveryStatusEvent(MultiUserEvent):
+class MessageDeliveryStatusEvent(UserEvent):
     service = 'chatd'
     name = 'chatd_message_delivery_status'
     routing_key_fmt = 'chatd.rooms.{room_uuid}.messages.{message_uuid}.delivery'
+    required_acl_fmt = 'events.chat.message.{message_uuid}.{user_uuid}.delivery'
 
     def __init__(
         self,
@@ -112,8 +113,8 @@ class MessageDeliveryStatusEvent(MultiUserEvent):
         room_uuid: UUIDStr,
         message_uuid: UUIDStr,
         tenant_uuid: UUIDStr,
-        user_uuids: list[UUIDStr],
+        user_uuid: UUIDStr,
     ) -> None:
-        super().__init__(delivery_data, tenant_uuid, user_uuids)
+        super().__init__(delivery_data, tenant_uuid, user_uuid)
         self.room_uuid = str(room_uuid)
         self.message_uuid = str(message_uuid)

--- a/wazo_bus/resources/chatd/events.py
+++ b/wazo_bus/resources/chatd/events.py
@@ -114,7 +114,13 @@ class MessageDeliveryStatusEvent(UserEvent):
         message_uuid: UUIDStr,
         tenant_uuid: UUIDStr,
         user_uuid: UUIDStr,
-    ) -> None:
+    ):
         super().__init__(delivery_data, tenant_uuid, user_uuid)
+        if room_uuid is None:
+            raise ValueError('room_uuid must have a value')
+
+        if message_uuid is None:
+            raise ValueError('message_uuid must have a value')
+
         self.room_uuid = str(room_uuid)
         self.message_uuid = str(message_uuid)

--- a/wazo_bus/resources/chatd/events.py
+++ b/wazo_bus/resources/chatd/events.py
@@ -1,11 +1,17 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
 
-from ..common.event import TenantEvent, UserEvent
+from ..common.event import MultiUserEvent, TenantEvent, UserEvent
 from ..common.types import UUIDStr
-from .types import MessageDict, RoomDict, UserPresenceDict
+from .types import (
+    DeliveryStatusDict,
+    MessageDict,
+    RoomDict,
+    UserIdentityDict,
+    UserPresenceDict,
+)
 
 
 class PresenceUpdatedEvent(TenantEvent):
@@ -51,3 +57,63 @@ class UserRoomMessageCreatedEvent(UserEvent):
         if room_uuid is None:
             raise ValueError('room_uuid must have a value')
         self.room_uuid = str(room_uuid)
+
+
+class UserIdentityCreatedEvent(UserEvent):
+    service = 'chatd'
+    name = 'chatd_user_identity_created'
+    routing_key_fmt = 'chatd.users.{user_uuid}.identities.created'
+
+    def __init__(
+        self,
+        identity_data: UserIdentityDict,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
+    ):
+        super().__init__(identity_data, tenant_uuid, user_uuid)
+
+
+class UserIdentityUpdatedEvent(UserEvent):
+    service = 'chatd'
+    name = 'chatd_user_identity_updated'
+    routing_key_fmt = 'chatd.users.{user_uuid}.identities.updated'
+
+    def __init__(
+        self,
+        identity_data: UserIdentityDict,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
+    ):
+        super().__init__(identity_data, tenant_uuid, user_uuid)
+
+
+class UserIdentityDeletedEvent(UserEvent):
+    service = 'chatd'
+    name = 'chatd_user_identity_deleted'
+    routing_key_fmt = 'chatd.users.{user_uuid}.identities.deleted'
+
+    def __init__(
+        self,
+        identity_data: UserIdentityDict,
+        tenant_uuid: UUIDStr,
+        user_uuid: UUIDStr,
+    ):
+        super().__init__(identity_data, tenant_uuid, user_uuid)
+
+
+class MessageDeliveryStatusEvent(MultiUserEvent):
+    service = 'chatd'
+    name = 'chatd_message_delivery_status'
+    routing_key_fmt = 'chatd.rooms.{room_uuid}.messages.{message_uuid}.delivery'
+
+    def __init__(
+        self,
+        delivery_data: DeliveryStatusDict,
+        room_uuid: UUIDStr,
+        message_uuid: UUIDStr,
+        tenant_uuid: UUIDStr,
+        user_uuids: list[UUIDStr],
+    ) -> None:
+        super().__init__(delivery_data, tenant_uuid, user_uuids)
+        self.room_uuid = str(room_uuid)
+        self.message_uuid = str(message_uuid)

--- a/wazo_bus/resources/chatd/types.py
+++ b/wazo_bus/resources/chatd/types.py
@@ -32,6 +32,8 @@ class MessageDict(TypedDict, total=False):
     uuid: UUIDStr
     content: str
     alias: str
+    type: str
+    backend: str
     user_uuid: UUIDStr
     tenant_uuid: UUIDStr
     wazo_uuid: UUIDStr

--- a/wazo_bus/resources/chatd/types.py
+++ b/wazo_bus/resources/chatd/types.py
@@ -28,12 +28,17 @@ class LinePresenceDict(TypedDict, total=False):
     state: str
 
 
+class MessageDeliveryDict(TypedDict, total=False):
+    type: str
+    backend: str
+    status: str
+
+
 class MessageDict(TypedDict, total=False):
     uuid: UUIDStr
     content: str
     alias: str
-    type: str
-    backend: str
+    delivery: MessageDeliveryDict
     user_uuid: UUIDStr
     tenant_uuid: UUIDStr
     wazo_uuid: UUIDStr

--- a/wazo_bus/resources/chatd/types.py
+++ b/wazo_bus/resources/chatd/types.py
@@ -10,6 +10,7 @@ from ..common.types import UUIDStr
 
 class DeliveryStatusDict(TypedDict, total=False):
     message_uuid: UUIDStr
+    recipient_identity: str
     status: str
     timestamp: str
     backend: str
@@ -31,7 +32,6 @@ class LinePresenceDict(TypedDict, total=False):
 class MessageDeliveryDict(TypedDict, total=False):
     type: str
     backend: str
-    status: str
 
 
 class MessageDict(TypedDict, total=False):

--- a/wazo_bus/resources/chatd/types.py
+++ b/wazo_bus/resources/chatd/types.py
@@ -1,4 +1,4 @@
-# Copyright 2023-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2023-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from __future__ import annotations
@@ -6,6 +6,21 @@ from __future__ import annotations
 from typing import TypedDict
 
 from ..common.types import UUIDStr
+
+
+class DeliveryStatusDict(TypedDict, total=False):
+    message_uuid: UUIDStr
+    status: str
+    timestamp: str
+    backend: str
+
+
+class UserIdentityDict(TypedDict, total=False):
+    uuid: UUIDStr
+    backend: str
+    type: str
+    identity: str
+    extra: dict[str, str]
 
 
 class LinePresenceDict(TypedDict, total=False):

--- a/wazo_bus/resources/chatd/types.py
+++ b/wazo_bus/resources/chatd/types.py
@@ -29,9 +29,16 @@ class LinePresenceDict(TypedDict, total=False):
     state: str
 
 
+class MessageRecipientDict(TypedDict, total=False):
+    identity: str
+    status: str
+    updated_at: str
+
+
 class MessageDeliveryDict(TypedDict, total=False):
     type: str
     backend: str
+    recipients: list[MessageRecipientDict]
 
 
 class MessageDict(TypedDict, total=False):


### PR DESCRIPTION
## Summary

Adds chatd bus event/payload types needed by the wazo-chatd connectors plugin (multichannel SMS support, see wazo-chatd PR #193).

- `UserIdentityCreated/Updated/Deleted` events fired when external messaging identities (SMS numbers, etc.) are linked to a user
- `MessageDeliveryStatus` event fired as outbound messages transition between accepted → sent → delivered / failed / dead_letter
- `MessageDict` gains `type` and `backend` so consumers can distinguish internal chat from external-channel messages
- Delivery fields are nested under `MessageDeliveryDict` so the message payload stays clean as more delivery metadata lands

## Test plan

- [ ] Unit tests in wazo-bus pass
- [ ] Used downstream by wazo-chatd PR #193 (events fire and payloads round-trip in integration tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new bus event types and extends `MessageDict` payloads, changing the event contract consumed by downstream services; risk is mainly around schema/ACL expectations and routing key usage.
> 
> **Overview**
> Adds new `chatd` bus events for external messaging integrations: `UserIdentityCreatedEvent`/`UpdatedEvent`/`DeletedEvent` plus `MessageDeliveryStatusEvent` (with `room_uuid`/`message_uuid` routing and a `required_acl_fmt`).
> 
> Extends chat message payload typing by introducing `DeliveryStatusDict`, `UserIdentityDict`, and nested delivery structures (`MessageDeliveryDict`/`MessageRecipientDict`), and adds an optional `delivery` field to `MessageDict` to carry per-recipient delivery metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b496ddbb832dea0cb83e2e97c18e42b049a60b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->