### PR TITLE
[ITEM-289] bus: exclusive queues with reconcile-on-iteration bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 *.pyc
 .coverage
 .tox
+/build/
 coverage.xml
 unit-tests.xml

--- a/integration_tests/Makefile
+++ b/integration_tests/Makefile
@@ -1,15 +1,12 @@
-test-setup: egg-info bus-test bus-documentation
+test-setup: bus-test bus-documentation
 
 test:
 	pytest -x
 
-egg-info:
-	cd .. && python setup.py egg_info
-
 bus-documentation:
 	docker build -t local/bus-documentation-test -f ../contribs/Dockerfile ..
 
-bus-test: egg-info
+bus-test:
 	docker build -t local/bus-test -f docker/Dockerfile-bus ..
 
-.PHONY: test-setup test egg-info bus-test bus-documentation
+.PHONY: test-setup test bus-test bus-documentation

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       TARGETS: "rabbitmq:5672 bus:5000"
 
   rabbitmq:
-    image: rabbitmq:3
+    image: rabbitmq
     ports:
       - "5672"
     volumes:

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import os
@@ -53,10 +53,15 @@ class BusIntegrationTest(AssetLaunchingTestCase):
     def start_rabbitmq(cls):
         cls.start_service('rabbitmq')
         port = cls.service_port(5672, 'rabbitmq')
-        # Note: only needed on integration tests because ports are dynamic
-        url = f'amqp://guest:guest@127.0.0.1:{port}//'
+        # Note: only needed on integration tests because ports are dynamic.
+        # Update _connection_params so self.url reflects the new port (used
+        # by future create_connection calls), and switch the standing
+        # Connection objects so in-flight retry loops pick up the new URL.
+        cls.local_bus._connection_params = cls.local_bus._connection_params._replace(
+            port=port
+        )
+        url = cls.local_bus.url
         cls.local_bus._PublisherMixin__connection.switch(url)
-        cls.local_bus._ConsumerMixin__connection.switch(url)
         cls.local_bus.connection.switch(url)
         wait_for_rabbitmq(cls)
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pyhamcrest
 pytest>=9.0
 pytest-cov
+setuptools

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -263,36 +263,58 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                 if in_desired == in_active:
                     self.__pending_events.pop(binding).set()
 
+    @contextmanager
+    def __open_channel(self) -> Iterator[StdChannel]:
+        channel = self.connection.channel()
+        try:
+            yield channel
+        finally:
+            try:
+                channel.close()
+            except (AttributeError, KeyError):
+                pass
+
     def __apply_binding_changes(
         self, to_add: set[Binding], to_remove: set[Binding]
     ) -> None:
         if self.__queue is None:
             return
 
-        channel = self.connection.default_channel
         errors = self.connection.connection_errors + self.connection.channel_errors
 
-        for binding in to_add:
-            try:
-                binding.bind(self.__queue, channel=channel)
-            except errors as exc:
-                self.log.warning('Failed to bind %s, will retry: %s', binding, exc)
-                continue
-            except NotFound as exc:
-                self.log.warning('Failed to bind %s, queue gone: %s', binding, exc)
-                continue
+        with self.__open_channel() as channel:
+            for binding in to_add:
+                try:
+                    binding.bind(self.__queue, channel=channel)
+                except NotFound as exc:
+                    self.log.warning(
+                        'Queue %s gone while binding %s, reconnecting: %s',
+                        self.__queue.name,
+                        binding,
+                        exc,
+                    )
+                    raise
+                except errors as exc:
+                    self.log.warning('Failed to bind %s, will retry: %s', binding, exc)
+                    continue
 
-            self.__queue.bindings.add(binding)
+                self.__queue.bindings.add(binding)
 
-        for binding in to_remove:
-            try:
-                binding.unbind(self.__queue, channel=channel)
-            except errors as exc:
-                self.log.warning('Failed to unbind %s: %s', binding, exc)
-            except NotFound:
-                pass
+            for binding in to_remove:
+                try:
+                    binding.unbind(self.__queue, channel=channel)
+                except NotFound as exc:
+                    self.log.warning(
+                        'Queue %s gone while unbinding %s, reconnecting: %s',
+                        self.__queue.name,
+                        binding,
+                        exc,
+                    )
+                    raise
+                except errors as exc:
+                    self.log.warning('Failed to unbind %s: %s', binding, exc)
 
-            self.__queue.bindings.discard(binding)
+                self.__queue.bindings.discard(binding)
 
     def __dispatch(
         self, event_name: str, payload: dict, headers: dict | None = None

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -180,21 +180,20 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
             Uninstall a handler for the specified event
     '''
 
-    consumer_args: ClassVar[dict] = {}
+    consumer_args: ClassVar[dict] = {'safety_interval': 0.2}
+    _binding_apply_timeout: ClassVar[float] = 5.0
 
     def __init__(self, **kwargs: Any):
         # NOTE(clanglois): Mixin expects a parent class to provide __init__ implementation
         super().__init__(**kwargs)  # type: ignore[safe-super]
-        name = f'{self._name}.{os.urandom(3).hex()}'
-        self.__connection = Connection(self.url)
         self.__subscriptions: defaultdict[str, list[Subscription]] = defaultdict(list)
-        self.__queue = AMQPQueue(name=name, auto_delete=True, durable=False)
+        self.__bindings: set[Binding] = set()
+        self.__pending_events: dict[Binding, Event] = {}
+        self.__queue: AMQPQueue | None = None
         self.__lock = Lock()
         self.__thread: Thread | None = None
         if hasattr(self, '_register_thread'):
-            self.__thread = self._register_thread(
-                'consumer', self.__thread_run, self.__thread_stop
-            )
+            self.__thread = self._register_thread('consumer', self.__thread_run)
 
         self.create_connection()
         self.log.debug('setting consuming exchange as \'%s\'', self._exchange)
@@ -203,46 +202,104 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         is_running = self.__thread.is_alive() if self.__thread is not None else True
         return bool(is_running and self.connection.connected)
 
-    @property
-    @contextmanager
-    def __binding_channel(self) -> Iterator[StdChannel]:
-        if not self.__connection.connected:
-            self.__connection.connect()
-        yield self.__connection.default_channel
+    def __should_wait_for_apply(self) -> bool:
+        return (
+            self.is_running
+            and self.__thread is not None
+            and current_thread() is not self.__thread
+        )
 
-    def __create_binding(self, headers: dict, routing_key: str | None) -> Binding:
+    def __register_binding(
+        self, headers: dict, routing_key: str | None, *, wait: bool
+    ) -> Binding:
         binding = Binding(self._exchange, routing_key, headers, headers)
-        self.__queue.bindings.add(binding)
-        if self.is_running:
-            try:
-                with self.__binding_channel as channel:
-                    self.__queue.queue_declare(passive=True, channel=channel)
-                    binding.bind(self.__queue, channel=channel)
-            except self.__connection.connection_errors as e:
-                self.log.error('Connection error while creating binding: %s', e)
-            except NotFound:
-                self.log.error(
-                    'Queue %s doesn\'t exist on the server', self.__queue.name
-                )
+
+        with self.__lock:
+            self.__bindings.add(binding)
+            if wait and self.__should_wait_for_apply():
+                self.__pending_events[binding] = Event()
+
         return binding
 
-    def __remove_binding(self, binding: Binding) -> None:
-        self.__queue.bindings.remove(binding)
-        if self.is_running:
+    def __unregister_binding(self, binding: Binding, *, wait: bool) -> None:
+        with self.__lock:
+            self.__bindings.discard(binding)
+            if wait and self.__should_wait_for_apply():
+                self.__pending_events[binding] = Event()
+
+    def __wait_for_binding(self, binding: Binding, target: str) -> None:
+        with self.__lock:
+            event = self.__pending_events.get(binding)
+
+        if event is None:
+            return
+
+        if not event.wait(timeout=self._binding_apply_timeout):
+            self.log.warning(
+                'Timed out waiting for binding of \'%s\' to be applied', target
+            )
+
+    def on_iteration(self) -> None:
+        if self.__queue is None:
+            return
+
+        active = self.__queue.bindings
+
+        with self.__lock:
+            to_add = self.__bindings - active
+            to_remove = active - self.__bindings
+
+        if not to_add and not to_remove and not self.__pending_events:
+            return
+
+        if to_add or to_remove:
+            self.__apply_binding_changes(to_add, to_remove)
+
+        with self.__lock:
+            for binding in list(self.__pending_events):
+                in_desired = binding in self.__bindings
+                in_active = binding in active
+
+                if in_desired == in_active:
+                    self.__pending_events.pop(binding).set()
+
+    def __apply_binding_changes(
+        self, to_add: set[Binding], to_remove: set[Binding]
+    ) -> None:
+        if self.__queue is None:
+            return
+
+        channel = self.connection.default_channel
+        errors = self.connection.connection_errors + self.connection.channel_errors
+
+        for binding in to_add:
             try:
-                with self.__binding_channel as channel:
-                    self.__queue.queue_declare(passive=True, channel=channel)
-                    binding.unbind(self.__queue, channel=channel)
-            except self.__connection.connection_errors:
-                self.log.exception('Connection error while removing binding: %s')
+                binding.bind(self.__queue, channel=channel)
+            except errors as exc:
+                self.log.warning('Failed to bind %s, will retry: %s', binding, exc)
+                continue
+            except NotFound as exc:
+                self.log.warning('Failed to bind %s, queue gone: %s', binding, exc)
+                continue
+
+            self.__queue.bindings.add(binding)
+
+        for binding in to_remove:
+            try:
+                binding.unbind(self.__queue, channel=channel)
+            except errors as exc:
+                self.log.warning('Failed to unbind %s: %s', binding, exc)
             except NotFound:
                 pass
+
+            self.__queue.bindings.discard(binding)
 
     def __dispatch(
         self, event_name: str, payload: dict, headers: dict | None = None
     ) -> None:
         with self.__lock:
             subscriptions = self.__subscriptions[event_name].copy()
+
         if subscriptions:
             self.log.debug(
                 'Received bus event: name=%s, headers=%s, payload=%s',
@@ -250,6 +307,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                 headers,
                 payload,
             )
+
         for handler, _ in subscriptions:
             try:
                 handler(payload)
@@ -281,23 +339,37 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         headers: dict | None = None,
         routing_key: str | None = None,
         headers_match_all: bool = True,
+        *,
+        wait: bool = True,
     ) -> None:
         headers = dict(headers or {})
         headers.update(name=event_name)
+
         if self._exchange.type == 'headers':
             headers.setdefault('x-match', 'all' if headers_match_all else 'any')
 
-        binding = self.__create_binding(headers, routing_key)
+        binding = self.__register_binding(headers, routing_key, wait=wait)
         subscription = Subscription(handler, binding)
+
         with self.__lock:
             self.__subscriptions[event_name].append(subscription)
+
+        if wait:
+            self.__wait_for_binding(binding, event_name)
+
         self.log.debug(
             'Registered handler \'%s\' to event \'%s\'',
             getattr(handler, '__name__', handler),
             event_name,
         )
 
-    def unsubscribe(self, event_name: str, handler: EventHandlerType) -> bool:
+    def unsubscribe(
+        self,
+        event_name: str,
+        handler: EventHandlerType,
+        *,
+        wait: bool = True,
+    ) -> bool:
         with self.__lock:
             subscriptions = self.__subscriptions[event_name].copy()
         try:
@@ -305,7 +377,11 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                 if subscription.handler == handler:
                     with self.__lock:
                         self.__subscriptions[event_name].remove(subscription)
-                    self.__remove_binding(subscription.binding)
+                    self.__unregister_binding(subscription.binding, wait=wait)
+
+                    if wait:
+                        self.__wait_for_binding(subscription.binding, event_name)
+
                     self.log.debug(
                         'Unregistered handler \'%s\' from \'%s\'',
                         getattr(handler, '__name__', handler),
@@ -321,6 +397,17 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     def get_consumers(
         self, Consumer: type[Consumer], channel: StdChannel
     ) -> list[Consumer]:
+        with self.__lock:
+            bindings = set(self.__bindings)
+
+        self.__queue = AMQPQueue(
+            name=f'{self._name}.{os.urandom(3).hex()}',
+            exclusive=True,
+            auto_delete=True,
+            durable=False,
+            bindings=bindings,
+        )
+
         self._exchange.bind(channel).declare()
         return [
             Consumer(
@@ -355,7 +442,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
             self.connection.release()
 
     def create_connection(self) -> Connection:
-        self.connection = self.__connection.clone()
+        self.connection = Connection(self.url)
         return self.connection
 
     @property
@@ -375,9 +462,6 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
 
     def __thread_run(self, ready_flag: Event, **kwargs: Any) -> None:
         super().run(ready_flag=ready_flag, **self.consumer_args)
-
-    def __thread_stop(self) -> None:
-        self.__connection.release()
 
 
 class PublisherMixin(BaseProtocol):

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import os
-from collections import defaultdict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -169,7 +168,12 @@ class ThreadableMixin(BaseProtocol):
 
 class ConsumerMixin(KombuConsumer, BaseProtocol):
     '''
-    Mixin to provide RabbitMQ message consuming capabilities
+    Mixin to provide RabbitMQ message consuming capabilities.
+
+    Bindings are reconciled against the broker from the consumer thread on
+    every `on_iteration` tick. By default, `subscribe`/`unsubscribe` block
+    until that reconciliation converges (or is cancelled by a concurrent
+    inverse call); pass `wait=False` to skip the wait.
 
     Public methods:
         * `consumer_connected`:
@@ -186,14 +190,17 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     def __init__(self, **kwargs: Any):
         # NOTE(clanglois): Mixin expects a parent class to provide __init__ implementation
         super().__init__(**kwargs)  # type: ignore[safe-super]
-        self.__subscriptions: defaultdict[str, list[Subscription]] = defaultdict(list)
+        self.__subscriptions: dict[str, list[Subscription]] = {}
         self.__bindings: set[Binding] = set()
-        self.__pending_events: dict[Binding, Event] = {}
+        self.__pending_binds: dict[Binding, Event] = {}
+        self.__pending_unbinds: dict[Binding, Event] = {}
         self.__queue: AMQPQueue | None = None
         self.__lock = Lock()
         self.__thread: Thread | None = None
         if hasattr(self, '_register_thread'):
-            self.__thread = self._register_thread('consumer', self.__thread_run)
+            self.__thread = self._register_thread(
+                'consumer', self.__thread_run, self.__thread_stop
+            )
 
         self.create_connection()
         self.log.debug('setting consuming exchange as \'%s\'', self._exchange)
@@ -205,63 +212,43 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     def __should_wait_for_apply(self) -> bool:
         return (
             self.is_running
+            and not self.is_stopping
             and self.__thread is not None
             and current_thread() is not self.__thread
         )
 
-    def __register_binding(
-        self, headers: dict, routing_key: str | None, *, wait: bool
-    ) -> Binding:
-        binding = Binding(self._exchange, routing_key, headers, headers)
-
-        with self.__lock:
-            self.__bindings.add(binding)
-            if wait and self.__should_wait_for_apply():
-                self.__pending_events[binding] = Event()
-
-        return binding
-
-    def __unregister_binding(self, binding: Binding, *, wait: bool) -> None:
-        with self.__lock:
-            self.__bindings.discard(binding)
-            if wait and self.__should_wait_for_apply():
-                self.__pending_events[binding] = Event()
-
-    def __wait_for_binding(self, binding: Binding, target: str) -> None:
-        with self.__lock:
-            event = self.__pending_events.get(binding)
-
-        if event is None:
-            return
-
+    def __wait_for_binding(self, event: Event, target: str) -> None:
         if not event.wait(timeout=self._binding_apply_timeout):
             self.log.warning(
-                'Timed out waiting for binding of \'%s\' to be applied', target
+                'Timed out waiting for binding state of \'%s\' to converge',
+                target,
             )
 
     def on_iteration(self) -> None:
         if self.__queue is None:
             return
 
-        active = self.__queue.bindings
+        active_bindings = self.__queue.bindings
 
         with self.__lock:
-            to_add = self.__bindings - active
-            to_remove = active - self.__bindings
+            to_add = self.__bindings - active_bindings
+            to_remove = active_bindings - self.__bindings
+            has_pending = bool(self.__pending_binds) or bool(self.__pending_unbinds)
 
-        if not to_add and not to_remove and not self.__pending_events:
+        if not to_add and not to_remove and not has_pending:
             return
 
         if to_add or to_remove:
             self.__apply_binding_changes(to_add, to_remove)
 
         with self.__lock:
-            for binding in list(self.__pending_events):
-                in_desired = binding in self.__bindings
-                in_active = binding in active
+            for binding in list(self.__pending_binds):
+                if binding in active_bindings or binding not in self.__bindings:
+                    self.__pending_binds.pop(binding).set()
 
-                if in_desired == in_active:
-                    self.__pending_events.pop(binding).set()
+            for binding in list(self.__pending_unbinds):
+                if binding not in active_bindings or binding in self.__bindings:
+                    self.__pending_unbinds.pop(binding).set()
 
     @contextmanager
     def __open_channel(self) -> Iterator[StdChannel]:
@@ -271,8 +258,8 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         finally:
             try:
                 channel.close()
-            except (AttributeError, KeyError):
-                pass
+            except Exception:
+                self.log.debug('Ignoring error while closing channel', exc_info=True)
 
     def __apply_binding_changes(
         self, to_add: set[Binding], to_remove: set[Binding]
@@ -312,7 +299,10 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                     )
                     raise
                 except errors as exc:
-                    self.log.warning('Failed to unbind %s: %s', binding, exc)
+                    self.log.warning(
+                        'Failed to unbind %s, will retry: %s', binding, exc
+                    )
+                    continue
 
                 self.__queue.bindings.discard(binding)
 
@@ -320,7 +310,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         self, event_name: str, payload: dict, headers: dict | None = None
     ) -> None:
         with self.__lock:
-            subscriptions = self.__subscriptions[event_name].copy()
+            subscriptions = tuple(self.__subscriptions.get(event_name, ()))
 
         if subscriptions:
             self.log.debug(
@@ -339,19 +329,20 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                     getattr(handler, '__name__', handler),
                     event_name,
                 )
-            continue
 
     def __extract_event_from_message(self, message: Message) -> tuple[str, dict, dict]:
         event_name = None
-        headers = message.headers
+        headers = dict(message.headers)
         payload = message.payload
+        if isinstance(payload, dict):
+            payload = dict(payload)
 
         if 'name' in headers:
             event_name = headers['name']
         elif isinstance(payload, dict) and 'name' in payload:
             event_name = payload['name']
         else:
-            raise ValueError('Received invalid messsage; no event name could be found.')
+            raise ValueError('Received invalid message; no event name could be found.')
         return event_name, headers, payload
 
     def subscribe(
@@ -370,14 +361,20 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         if self._exchange.type == 'headers':
             headers.setdefault('x-match', 'all' if headers_match_all else 'any')
 
-        binding = self.__register_binding(headers, routing_key, wait=wait)
+        binding = Binding(self._exchange, routing_key, headers, headers)
         subscription = Subscription(handler, binding)
+        should_wait = wait and self.__should_wait_for_apply()
+        event: Event | None = None
 
         with self.__lock:
-            self.__subscriptions[event_name].append(subscription)
+            self.__subscriptions.setdefault(event_name, []).append(subscription)
+            self.__bindings.add(binding)
+            if should_wait and not self.is_stopping:
+                event = Event()
+                self.__pending_binds[binding] = event
 
-        if wait:
-            self.__wait_for_binding(binding, event_name)
+        if event is not None:
+            self.__wait_for_binding(event, event_name)
 
         self.log.debug(
             'Registered handler \'%s\' to event \'%s\'',
@@ -392,29 +389,37 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         *,
         wait: bool = True,
     ) -> bool:
+        should_wait = wait and self.__should_wait_for_apply()
+        event: Event | None = None
+
         with self.__lock:
-            subscriptions = self.__subscriptions[event_name].copy()
-        try:
-            for subscription in subscriptions:
-                if subscription.handler == handler:
-                    with self.__lock:
-                        self.__subscriptions[event_name].remove(subscription)
-                    self.__unregister_binding(subscription.binding, wait=wait)
+            subscriptions = self.__subscriptions.get(event_name)
+            if subscriptions is None:
+                return False
 
-                    if wait:
-                        self.__wait_for_binding(subscription.binding, event_name)
+            matching = next((s for s in subscriptions if s.handler == handler), None)
+            if matching is None:
+                return False
 
-                    self.log.debug(
-                        'Unregistered handler \'%s\' from \'%s\'',
-                        getattr(handler, '__name__', handler),
-                        event_name,
-                    )
-                    return True
-            return False
-        finally:
-            if not self.__subscriptions[event_name]:
-                with self.__lock:
-                    self.__subscriptions.pop(event_name)
+            subscriptions.remove(matching)
+            self.__bindings.discard(matching.binding)
+
+            if not subscriptions:
+                self.__subscriptions.pop(event_name)
+
+            if should_wait and not self.is_stopping:
+                event = Event()
+                self.__pending_unbinds[matching.binding] = event
+
+        if event is not None:
+            self.__wait_for_binding(event, event_name)
+
+        self.log.debug(
+            'Unregistered handler \'%s\' from \'%s\'',
+            getattr(handler, '__name__', handler),
+            event_name,
+        )
+        return True
 
     def get_consumers(
         self, Consumer: type[Consumer], channel: StdChannel
@@ -439,16 +444,15 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
             )
         ]
 
-    def __on_message_received(self, body: Any, message: Message) -> None:
-        event_name, headers, payload = self.__extract_event_from_message(message)
-        if event_name not in self.__subscriptions:
-            return
+    def __on_message_received(self, _body: Any, message: Message) -> None:
         try:
+            event_name, headers, payload = self.__extract_event_from_message(message)
+            if event_name not in self.__subscriptions:
+                return
             headers, payload = self._unmarshal(event_name, headers, payload)
-        except Exception:
-            raise
-        else:
             self.__dispatch(event_name, payload, headers)
+        except Exception:
+            self.log.exception('Failed to process message')
         finally:
             message.ack()
 
@@ -484,6 +488,17 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
 
     def __thread_run(self, ready_flag: Event, **kwargs: Any) -> None:
         super().run(ready_flag=ready_flag, **self.consumer_args)
+
+    def __thread_stop(self) -> None:
+        with self.__lock:
+            for event in self.__pending_binds.values():
+                event.set()
+
+            for event in self.__pending_unbinds.values():
+                event.set()
+
+            self.__pending_binds.clear()
+            self.__pending_unbinds.clear()
 
 
 class PublisherMixin(BaseProtocol):


### PR DESCRIPTION
## Summary
- Switch the consumer's AMQP queue to `exclusive=True`, regenerated per `get_consumers` call so reconnects never hit `precondition_failed`.
- Drop the secondary `__connection` (incompatible with exclusive queues) and reconcile bindings on the consumer thread via Kombu's `on_iteration` hook (`safety_interval=0.2s` → ~200ms apply latency).
- `subscribe`/`unsubscribe` stay synchronous by default (per-binding `Event`); add a keyword-only `wait=` opt-out for fire-and-forget callers.
- Synchronization hardening (post-review):
  - Cancelled pending events now `.set()` immediately on the next `on_iteration` instead of stalling for the 5s convergence timeout.
  - In-lock `is_stopping` re-check in subscribe/unsubscribe avoids registering stranded events when `__thread_stop` ran between the should_wait check and lock acquisition.
  - `__on_message_received` restores the no-subscribers early-return so unmarshal isn't run for messages that arrived during the unsubscribe race window.
  - `__open_channel` close widened from `(AttributeError, KeyError)` to `Exception` with a debug log, so a broken-channel close can't abort `on_iteration`.
  - `should_wait` computed before lock acquisition (keeps the critical section to atomic dict mutations only).
- Adapt the integration test helper to update `_connection_params` (so `self.url` reflects the dynamic port across reconnects) and drop the obsolete `_ConsumerMixin__connection.switch` call.
- Side cleanups: drop the legacy `python setup.py egg_info` Makefile step (Dockerfiles regenerate it via `pip install -e .`), add `setuptools` to `test-requirements.txt` (uv venvs are minimal), ignore `/build/`.

## Test plan
- [x] `pre-commit run --files wazo_bus/mixins.py` — flake8/black/isort/mypy clean
- [x] `pytest suite/` (integration) — 23 passed
- [x] Verify in a downstream service (e.g. wazo-calld) that consumers come up cleanly and survive a rabbitmq restart
