### PR TITLE
bus: async subscribe/unsubscribe with wait_synchronized barrier

### DIFF
--- a/integration_tests/docker/remote-bus-pilot.py
+++ b/integration_tests/docker/remote-bus-pilot.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -136,6 +136,7 @@ def subscribe(event):
     headers, routing_key, _ = process_json(event, request.json, use_match=True)
     handler = create_event_handler(event, headers, routing_key)
     bus.subscribe(event, handler, headers, routing_key)
+    bus.wait_synchronized(timeout=5.0)
     info('Subscribed to \'%s\' (headers: %s)', event, headers)
     return make_response(
         200,
@@ -153,6 +154,7 @@ def unsubscribe(event):
     handler = broker.unbind_handler(event, headers, routing_key)
     if handler:
         bus.unsubscribe(event, handler)
+        bus.wait_synchronized(timeout=5.0)
         info('Unsubscribed from \'%s\' (headers: %s)', event, headers)
         return make_response(200, 'Unregistered event handler', event=event)
     return make_response(400, 'Handler not found', event=event)

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -138,7 +138,7 @@ class BusIntegrationTest(AssetLaunchingTestCase):
     @classmethod
     def remote_messages(cls, event_name, expected=None, timeout=3.0):
         def test():
-            return cls.remote_bus.get_messages_count == expected
+            return cls.remote_bus.get_messages_count(event_name) == expected
 
         try:
             until.true(test, timeout=timeout, interval=0.1)

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -116,11 +116,13 @@ class BusIntegrationTest(AssetLaunchingTestCase):
         handler = cls._local_messages.create_handler(event)
         try:
             cls.local_bus.subscribe(event, handler, headers, routing_key)
+            cls.local_bus.wait_synchronized(timeout=5.0)
             yield
         except Exception:
             raise
         finally:
             assert_that(cls.local_bus.unsubscribe(event, handler), is_(True))
+            cls.local_bus.wait_synchronized(timeout=5.0)
 
     @classmethod
     def local_messages(cls, event_name, expected=None, timeout=3.0):

--- a/integration_tests/suite/test_headers.py
+++ b/integration_tests/suite/test_headers.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime
@@ -73,10 +73,15 @@ class TestHeaders(BusIntegrationTest):
 
         with self.local_event(event.name, headers=headers):
             self.local_bus.publish(
-                event, payload={'value': 'something'}, headers={'required': False}
+                event, payload={'value': 'wrong'}, headers={'required': False}
+            )
+            self.local_bus.publish(
+                event, payload={'value': 'right'}, headers={'required': True}
             )
 
-            assert_that(self.local_messages(event.name), is_(empty()))
+            messages = self.local_messages(event.name, 1)
+            assert_that(messages, has_length(1))
+            assert_that(messages, has_item(has_entry('value', 'right')))
 
     def test_publish_ignore_extra_headers(self):
         event = MockEvent('extra_ignored_headers', some='payload')

--- a/integration_tests/suite/test_headers.py
+++ b/integration_tests/suite/test_headers.py
@@ -35,7 +35,7 @@ class TestHeaders(BusIntegrationTest):
             )
 
         self.local_bus.publish(event2)
-        assert_that(self.local_messages(event_name, 1), is_(empty()))
+        assert_that(self.local_messages(event_name, 1, timeout=1.0), is_(empty()))
 
     def test_routing_key_disabled_with_headers_exchange(self):
         event_name = 'routing_key_event'

--- a/integration_tests/suite/test_routing_key.py
+++ b/integration_tests/suite/test_routing_key.py
@@ -35,7 +35,7 @@ class TestRoutingKey(BusIntegrationTest):
             )
 
         self.local_bus.publish(event)
-        assert_that(self.local_messages(event.name, 1), is_(empty()))
+        assert_that(self.local_messages(event.name, 1, timeout=1.0), is_(empty()))
 
     def test_good_routing_key(self):
         event = MockEvent('good_routing_key', data='payload')
@@ -66,7 +66,7 @@ class TestRoutingKey(BusIntegrationTest):
         with self.local_event(event.name, routing_key=None):
             self.local_bus.publish(event, routing_key='events.bus.somewhere')
 
-            assert_that(self.local_messages(event.name), is_(empty()))
+            assert_that(self.local_messages(event.name, timeout=1.0), is_(empty()))
 
     def test_no_routing_key(self):
         no_key = MockEvent('no_publish_key', data='no_key')

--- a/integration_tests/suite/test_routing_key.py
+++ b/integration_tests/suite/test_routing_key.py
@@ -1,4 +1,4 @@
-# Copyright 2021-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2021-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from datetime import datetime
@@ -11,6 +11,7 @@ from hamcrest import (
     has_item,
     has_items,
     has_key,
+    has_length,
     is_,
 )
 
@@ -48,12 +49,16 @@ class TestRoutingKey(BusIntegrationTest):
             )
 
     def test_wrong_routing_key(self):
-        event = MockEvent('wrong_routing_key', data='something')
+        wrong = MockEvent('wrong_routing_key', data='wrong')
+        right = MockEvent('wrong_routing_key', data='right')
 
-        with self.local_event(event.name, routing_key='events.bus.good.#'):
-            self.local_bus.publish(event, routing_key='events.bus.wrong')
+        with self.local_event(wrong.name, routing_key='events.bus.good.#'):
+            self.local_bus.publish(wrong, routing_key='events.bus.wrong')
+            self.local_bus.publish(right, routing_key='events.bus.good.1')
 
-            assert_that(self.local_messages(event.name), is_(empty()))
+            messages = self.local_messages(wrong.name, 1)
+            assert_that(messages, has_length(1))
+            assert_that(messages, has_item(has_entry('data', 'right')))
 
     def test_no_event_routing_key(self):
         event = MockEvent('no_key', data='something')
@@ -64,12 +69,16 @@ class TestRoutingKey(BusIntegrationTest):
             assert_that(self.local_messages(event.name), is_(empty()))
 
     def test_no_routing_key(self):
-        event = MockEvent('no_publish_key', data='payload')
+        no_key = MockEvent('no_publish_key', data='no_key')
+        with_key = MockEvent('no_publish_key', data='with_key')
 
-        with self.local_event(event.name, routing_key='events.bus.good.#'):
-            self.local_bus.publish(event, routing_key=None)
+        with self.local_event(no_key.name, routing_key='events.bus.good.#'):
+            self.local_bus.publish(no_key, routing_key=None)
+            self.local_bus.publish(with_key, routing_key='events.bus.good.1')
 
-            assert_that(self.local_messages(event.name), is_(empty()))
+            messages = self.local_messages(no_key.name, 1)
+            assert_that(messages, has_length(1))
+            assert_that(messages, has_item(has_entry('data', 'with_key')))
 
     def test_headers_disabled_when_using_routing_key(self):
         event = MockEvent('headers_test', data='payload')

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -196,8 +196,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         self.__subscriptions: dict[str, list[Subscription]] = {}
         self.__bindings: set[Binding] = set()
         self.__queue: AMQPQueue | None = None
-        self.__lock = Lock()
-        self.__synced = Condition(self.__lock)
+        self.__synced = Condition(Lock())
         self.__thread: Thread | None = None
         if hasattr(self, '_register_thread'):
             self.__thread = self._register_thread(
@@ -233,9 +232,8 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         if self.__queue is None:
             return
 
-        active_before = set(self.__queue.bindings)
-
-        with self.__lock:
+        with self.__synced:
+            active_before = set(self.__queue.bindings)
             to_add = self.__bindings - active_before
             to_remove = active_before - self.__bindings
 
@@ -266,6 +264,8 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
             return
 
         errors = self.connection.connection_errors + self.connection.channel_errors
+        added: set[Binding] = set()
+        removed: set[Binding] = set()
 
         with self.__open_channel() as channel:
             for binding in to_add:
@@ -282,8 +282,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                 except errors as exc:
                     self.log.warning('Failed to bind %s, will retry: %s', binding, exc)
                     continue
-
-                self.__queue.bindings.add(binding)
+                added.add(binding)
 
             for binding in to_remove:
                 try:
@@ -301,13 +300,16 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                         'Failed to unbind %s, will retry: %s', binding, exc
                     )
                     continue
+                removed.add(binding)
 
-                self.__queue.bindings.discard(binding)
+        with self.__synced:
+            self.__queue.bindings |= added
+            self.__queue.bindings -= removed
 
     def __dispatch(
         self, event_name: str, payload: dict, headers: dict | None = None
     ) -> None:
-        with self.__lock:
+        with self.__synced:
             subscriptions = tuple(self.__subscriptions.get(event_name, ()))
 
         if subscriptions:
@@ -360,7 +362,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         binding = Binding(self._exchange, routing_key, headers, headers)
         subscription = Subscription(handler, binding)
 
-        with self.__lock:
+        with self.__synced:
             self.__subscriptions.setdefault(event_name, []).append(subscription)
             self.__bindings.add(binding)
 
@@ -375,7 +377,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         event_name: str,
         handler: EventHandlerType,
     ) -> bool:
-        with self.__lock:
+        with self.__synced:
             subscriptions = self.__subscriptions.get(event_name)
             if subscriptions is None:
                 return False
@@ -400,16 +402,14 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     def get_consumers(
         self, Consumer: type[Consumer], channel: StdChannel
     ) -> list[Consumer]:
-        with self.__lock:
-            bindings = set(self.__bindings)
-
-        self.__queue = AMQPQueue(
-            name=f'{self._name}.{os.urandom(3).hex()}',
-            exclusive=True,
-            auto_delete=True,
-            durable=False,
-            bindings=bindings,
-        )
+        with self.__synced:
+            self.__queue = AMQPQueue(
+                name=f'{self._name}.{os.urandom(3).hex()}',
+                exclusive=True,
+                auto_delete=True,
+                durable=False,
+                bindings=set(self.__bindings),
+            )
 
         self._exchange.bind(channel).declare()
         return [
@@ -461,6 +461,8 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         if 'ready_flag' in kwargs:
             ready_flag = kwargs.pop('ready_flag')
             ready_flag.set()
+        with self.__synced:
+            self.__synced.notify_all()
 
     def __thread_run(self, ready_flag: Event, **kwargs: Any) -> None:
         super().run(ready_flag=ready_flag, **self.consumer_args)

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -8,7 +8,8 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from datetime import datetime
 from queue import Empty, Queue
-from threading import Event, Lock, Thread, current_thread, main_thread
+from threading import Condition, Event, Lock, Thread, current_thread, main_thread
+from time import monotonic
 from typing import Any, ClassVar, NamedTuple, Protocol, Self
 
 from amqp.exceptions import NotFound
@@ -171,9 +172,10 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     Mixin to provide RabbitMQ message consuming capabilities.
 
     Bindings are reconciled against the broker from the consumer thread on
-    every `on_iteration` tick. By default, `subscribe`/`unsubscribe` block
-    until that reconciliation converges (or is cancelled by a concurrent
-    inverse call); pass `wait=False` to skip the wait.
+    every `on_iteration` tick. `subscribe`/`unsubscribe` mutate the desired
+    state and return immediately; convergence happens within one
+    `safety_interval`. Callers that need a barrier (tests, batched
+    setup/teardown) can use `wait_synchronized()`.
 
     Public methods:
         * `consumer_connected`:
@@ -182,6 +184,8 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
             Install a handler for the specified event
         * `unsubscribe`:
             Uninstall a handler for the specified event
+        * `wait_synchronized`:
+            Block until desired bindings are live at the broker
     '''
 
     consumer_args: ClassVar[dict] = {'safety_interval': 0.2}
@@ -196,6 +200,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         self.__pending_unbinds: dict[Binding, Event] = {}
         self.__queue: AMQPQueue | None = None
         self.__lock = Lock()
+        self.__synced = Condition(self.__lock)
         self.__thread: Thread | None = None
         if hasattr(self, '_register_thread'):
             self.__thread = self._register_thread(
@@ -224,15 +229,33 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
                 target,
             )
 
+    def __is_synced(self) -> bool:
+        if self.__queue is None:
+            return not self.__bindings
+        return self.__bindings == self.__queue.bindings
+
+    def wait_synchronized(self, timeout: float = 5.0) -> bool:
+        deadline = monotonic() + timeout
+        with self.__synced:
+            while True:
+                if self.is_stopping:
+                    return False
+                if self.__is_synced():
+                    return True
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    return False
+                self.__synced.wait(timeout=remaining)
+
     def on_iteration(self) -> None:
         if self.__queue is None:
             return
 
-        active_bindings = self.__queue.bindings
+        active_before = set(self.__queue.bindings)
 
         with self.__lock:
-            to_add = self.__bindings - active_bindings
-            to_remove = active_bindings - self.__bindings
+            to_add = self.__bindings - active_before
+            to_remove = active_before - self.__bindings
             has_pending = bool(self.__pending_binds) or bool(self.__pending_unbinds)
 
         if not to_add and not to_remove and not has_pending:
@@ -241,14 +264,17 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         if to_add or to_remove:
             self.__apply_binding_changes(to_add, to_remove)
 
-        with self.__lock:
+        with self.__synced:
             for binding in list(self.__pending_binds):
-                if binding in active_bindings or binding not in self.__bindings:
+                if binding in self.__queue.bindings or binding not in self.__bindings:
                     self.__pending_binds.pop(binding).set()
 
             for binding in list(self.__pending_unbinds):
-                if binding not in active_bindings or binding in self.__bindings:
+                if binding not in self.__queue.bindings or binding in self.__bindings:
                     self.__pending_unbinds.pop(binding).set()
+
+            if self.__queue.bindings != active_before:
+                self.__synced.notify_all()
 
     @contextmanager
     def __open_channel(self) -> Iterator[StdChannel]:
@@ -490,7 +516,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         super().run(ready_flag=ready_flag, **self.consumer_args)
 
     def __thread_stop(self) -> None:
-        with self.__lock:
+        with self.__synced:
             for event in self.__pending_binds.values():
                 event.set()
 
@@ -499,6 +525,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
 
             self.__pending_binds.clear()
             self.__pending_unbinds.clear()
+            self.__synced.notify_all()
 
 
 class PublisherMixin(BaseProtocol):

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -189,15 +189,12 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     '''
 
     consumer_args: ClassVar[dict] = {'safety_interval': 0.2}
-    _binding_apply_timeout: ClassVar[float] = 5.0
 
     def __init__(self, **kwargs: Any):
         # NOTE(clanglois): Mixin expects a parent class to provide __init__ implementation
         super().__init__(**kwargs)  # type: ignore[safe-super]
         self.__subscriptions: dict[str, list[Subscription]] = {}
         self.__bindings: set[Binding] = set()
-        self.__pending_binds: dict[Binding, Event] = {}
-        self.__pending_unbinds: dict[Binding, Event] = {}
         self.__queue: AMQPQueue | None = None
         self.__lock = Lock()
         self.__synced = Condition(self.__lock)
@@ -213,21 +210,6 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
     def consumer_connected(self) -> bool:
         is_running = self.__thread.is_alive() if self.__thread is not None else True
         return bool(is_running and self.connection.connected)
-
-    def __should_wait_for_apply(self) -> bool:
-        return (
-            self.is_running
-            and not self.is_stopping
-            and self.__thread is not None
-            and current_thread() is not self.__thread
-        )
-
-    def __wait_for_binding(self, event: Event, target: str) -> None:
-        if not event.wait(timeout=self._binding_apply_timeout):
-            self.log.warning(
-                'Timed out waiting for binding state of \'%s\' to converge',
-                target,
-            )
 
     def __is_synced(self) -> bool:
         if self.__queue is None:
@@ -256,23 +238,13 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         with self.__lock:
             to_add = self.__bindings - active_before
             to_remove = active_before - self.__bindings
-            has_pending = bool(self.__pending_binds) or bool(self.__pending_unbinds)
 
-        if not to_add and not to_remove and not has_pending:
+        if not to_add and not to_remove:
             return
 
-        if to_add or to_remove:
-            self.__apply_binding_changes(to_add, to_remove)
+        self.__apply_binding_changes(to_add, to_remove)
 
         with self.__synced:
-            for binding in list(self.__pending_binds):
-                if binding in self.__queue.bindings or binding not in self.__bindings:
-                    self.__pending_binds.pop(binding).set()
-
-            for binding in list(self.__pending_unbinds):
-                if binding not in self.__queue.bindings or binding in self.__bindings:
-                    self.__pending_unbinds.pop(binding).set()
-
             if self.__queue.bindings != active_before:
                 self.__synced.notify_all()
 
@@ -378,8 +350,6 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         headers: dict | None = None,
         routing_key: str | None = None,
         headers_match_all: bool = True,
-        *,
-        wait: bool = True,
     ) -> None:
         headers = dict(headers or {})
         headers.update(name=event_name)
@@ -389,18 +359,10 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
 
         binding = Binding(self._exchange, routing_key, headers, headers)
         subscription = Subscription(handler, binding)
-        should_wait = wait and self.__should_wait_for_apply()
-        event: Event | None = None
 
         with self.__lock:
             self.__subscriptions.setdefault(event_name, []).append(subscription)
             self.__bindings.add(binding)
-            if should_wait and not self.is_stopping:
-                event = Event()
-                self.__pending_binds[binding] = event
-
-        if event is not None:
-            self.__wait_for_binding(event, event_name)
 
         self.log.debug(
             'Registered handler \'%s\' to event \'%s\'',
@@ -412,12 +374,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         self,
         event_name: str,
         handler: EventHandlerType,
-        *,
-        wait: bool = True,
     ) -> bool:
-        should_wait = wait and self.__should_wait_for_apply()
-        event: Event | None = None
-
         with self.__lock:
             subscriptions = self.__subscriptions.get(event_name)
             if subscriptions is None:
@@ -432,13 +389,6 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
 
             if not subscriptions:
                 self.__subscriptions.pop(event_name)
-
-            if should_wait and not self.is_stopping:
-                event = Event()
-                self.__pending_unbinds[matching.binding] = event
-
-        if event is not None:
-            self.__wait_for_binding(event, event_name)
 
         self.log.debug(
             'Unregistered handler \'%s\' from \'%s\'',
@@ -517,14 +467,6 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
 
     def __thread_stop(self) -> None:
         with self.__synced:
-            for event in self.__pending_binds.values():
-                event.set()
-
-            for event in self.__pending_unbinds.values():
-                event.set()
-
-            self.__pending_binds.clear()
-            self.__pending_unbinds.clear()
             self.__synced.notify_all()
 
 


### PR DESCRIPTION
## Summary

- `subscribe`/`unsubscribe` are now strictly asynchronous: they mutate the desired-bindings set and return immediately. Convergence at the broker happens within one consumer tick (`safety_interval`, currently 200ms).
- A new `wait_synchronized(timeout=5.0)` method gives callers a first-class barrier when they need one. It blocks until desired bindings match what the broker has applied, and supports batching (subscribe N times, wait once).
- The legacy `wait=True` flag and its supporting machinery (`__pending_binds`, `__pending_unbinds`, `__should_wait_for_apply`, `__wait_for_binding`, the per-binding `Event` accounting) are removed.

The default `wait=True` was paying per-call latency for a guarantee no production caller actually needed - in particular webhookd's per-API-request CRUD flow, which hit the floor on every subscription mutation. Eventual-consistency semantics match the de-facto behavior of every comparable framework (Spring AMQP's `addQueueNames`, aio_pika's `await queue.bind`, the RabbitMQ MQTT plugin's per-client queues).

## Test perf cleanup

Three follow-up commits clean up unrelated waste in the integration suite that the rework exposed:

- Fix a long-standing bug in `remote_messages` (was comparing a method reference, polled the full 3s timeout on every call).
- Convert three negative assertions (`test_wrong_routing_key`, `test_no_routing_key`, `test_publish_wrong_expected_headers_value`) to positive sentinel-based assertions. They now finish as soon as the matching message arrives instead of waiting out the timeout.
- Shorten the `local_messages` timeout from 3s to 1s on three remaining negative tests where positive conversion would obscure intent.

Suite went from 122s -> 104s end-to-end.

## Test plan

- [x] All 23 integration tests pass on each commit (verified locally).
- [x] `pre-commit` hooks pass (flake8, black, pyupgrade, isort, mypy).
- [ ] CI green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the synchronization semantics of `ConsumerMixin.subscribe()`/`unsubscribe()` and replaces per-call blocking with an explicit barrier, which could affect callers that implicitly relied on immediate broker convergence. Touches core threading/synchronization code for consumer bindings.
> 
> **Overview**
> `ConsumerMixin.subscribe()`/`unsubscribe()` no longer block waiting for broker-side binding changes; they now only update desired state, with convergence handled asynchronously on the consumer loop. A new `wait_synchronized(timeout=...)` barrier was added (using a `Condition`) to allow tests/batch setup to explicitly wait until the desired bindings match the broker-applied bindings.
> 
> Integration test harnesses were updated to call `wait_synchronized()` after subscribe/unsubscribe, fix `remote_messages()` polling to call `get_messages_count(event_name)`, and adjust a few routing-key/headers tests to avoid long negative waits (shorter timeouts and positive sentinel assertions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01aa38eb9267ae24b765c631d9540e3749bb4610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->