### PR TITLE
bus: re-expose __lock on ConsumerMixin for downstream overrides

### DIFF
--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -196,7 +196,8 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
         self.__subscriptions: dict[str, list[Subscription]] = {}
         self.__bindings: set[Binding] = set()
         self.__queue: AMQPQueue | None = None
-        self.__synced = Condition(Lock())
+        self.__lock = Lock()
+        self.__synced = Condition(self.__lock)
         self.__thread: Thread | None = None
         if hasattr(self, '_register_thread'):
             self.__thread = self._register_thread(


### PR DESCRIPTION
## Summary
- Re-introduce `self.__lock = Lock()` on `ConsumerMixin` and construct `self.__synced = Condition(self.__lock)` over it, so the two primitives share the same underlying mutex.
- Restores the private attribute that wazo-sysconfd and wazo-webhookd rely on (via name-mangling) to override `__dispatch` and pass `headers` to handlers. The recent sync refactor (#142) replaced `__lock` with `__synced`, breaking both overrides at runtime.

## Why this shape
- Aliasing `__lock = __synced` would lie about the type (Condition vs Lock) and confuse anyone reading the override.
- Porting both downstream services to `__synced` is a coordinated 3-repo release that leaves the same fragile pattern in place (they still depend on `__subscriptions` and the mangled `__dispatch` name).
- This split is a one-line change that unblocks downstream without changing semantics. A proper fix — teaching `ConsumerMixin.__dispatch` to dispatch 2-arg handlers natively and deleting both overrides — is left as a follow-up.

## Test plan
- [x] `pre-commit run --files wazo_bus/mixins.py` passes (flake8, black, isort, mypy, etc.)
- [x] Manual smoke check: `BusConsumer()._ConsumerMixin__lock` is a `Lock`, and holding it blocks `_ConsumerMixin__synced.acquire(blocking=False)` (confirming they share the primitive).
- [ ] Integration test suite passes against running RabbitMQ.
- [ ] Downstream sanity: wazo-sysconfd and wazo-webhookd consumers receive dispatched events with headers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change limited to `ConsumerMixin` initialization; it reintroduces a private mutex used by downstream overrides and keeps synchronization semantics by sharing the same underlying lock with `__synced`.
> 
> **Overview**
> Restores the private `ConsumerMixin` mutex by reintroducing `self.__lock = Lock()` and constructing `self.__synced = Condition(self.__lock)`.
> 
> This re-exposes the name-mangled `__lock` attribute relied on by downstream services while keeping `Condition`-based synchronization on the same underlying lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d50eb3b86e62fb70f99f40c0c170eb76ade5cab2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->