### PR TITLE
bus: validate payload type and stop swallowing consumer exceptions

### DIFF
--- a/integration_tests/suite/test_headers.py
+++ b/integration_tests/suite/test_headers.py
@@ -5,6 +5,7 @@ from datetime import datetime
 
 from hamcrest import (
     assert_that,
+    calling,
     empty,
     has_entries,
     has_entry,
@@ -13,6 +14,7 @@ from hamcrest import (
     has_key,
     has_length,
     is_,
+    raises,
 )
 
 from .helpers.base import BusIntegrationTest
@@ -193,3 +195,20 @@ class TestHeaders(BusIntegrationTest):
                 self.local_messages(event_name, 1),
                 has_items(has_entries(id=4567, value='something')),
             )
+
+    def test_unmarshal_rejects_non_dict_payload(self):
+        assert_that(
+            calling(self.local_bus._unmarshal).with_args(
+                'some_event', {'name': 'some_event'}, 'not a dict'
+            ),
+            raises(ValueError),
+        )
+
+    def test_unmarshal_accepts_dict_payload(self):
+        headers, data = self.local_bus._unmarshal(
+            'some_event',
+            {'name': 'some_event'},
+            {'name': 'some_event', 'data': {'value': 42}},
+        )
+        assert_that(headers, has_entry('name', 'some_event'))
+        assert_that(data, has_entry('value', 42))

--- a/wazo_bus/mixins.py
+++ b/wazo_bus/mixins.py
@@ -430,6 +430,7 @@ class ConsumerMixin(KombuConsumer, BaseProtocol):
             self.__dispatch(event_name, payload, headers)
         except Exception:
             self.log.exception('Failed to process message')
+            raise
         finally:
             message.ack()
 
@@ -686,6 +687,11 @@ class WazoEventMixin(BaseProtocol):
     def _unmarshal(
         self, event_name: str, headers: dict, payload: dict
     ) -> tuple[dict, dict]:
+        if not isinstance(payload, dict):
+            raise ValueError(
+                f"Invalid payload for event '{event_name}': "
+                f"expected dict, got {type(payload).__name__}"
+            )
         event_data = payload.pop('data')
         headers = headers or payload
         return headers, event_data


### PR DESCRIPTION
## Summary
- `WazoEventMixin._unmarshal` now validates that `payload` is a dict before calling `.pop('data')`, raising a clear `ValueError` instead of the cryptic `AttributeError: 'str' object has no attribute 'pop'` that downstream services (e.g. calld) were hitting on non-JSON bus messages.
- `ConsumerMixin.__on_message_received` no longer swallows every exception. It still logs and acks (via the existing `finally`), but re-raises so the failure propagates to Kombu's drain loop — restoring the pre-#141 contract that downstream handlers like calld's bus consumer relied on to react to malformed messages.

## Context
The combined regression was introduced by PRs #141/#142 (exclusive consumer queues + tightened synchronization), which wrapped the message-processing pipeline in `except Exception: self.log.exception(...)` without re-raising. The `_unmarshal` bug had been latent — `__extract_event_from_message` only validates payload-is-dict on its fallback branch, so any message with a `name` header and a non-dict body slipped through to `_unmarshal` and crashed there.

## Test plan
- [x] `python -m pytest wazo_bus` — unit tests still pass
- [x] `pre-commit run --files wazo_bus/mixins.py integration_tests/suite/test_headers.py` — black/isort/flake8/mypy all green
- [ ] `make -C integration_tests test-setup && pytest integration_tests/suite/test_headers.py::TestHeaders::test_unmarshal_rejects_non_dict_payload integration_tests/suite/test_headers.py::TestHeaders::test_unmarshal_accepts_dict_payload` — to be run in CI
- [ ] Re-run the calld `TestARIReconnection.test_when_asterisk_sends_non_json_events_then_calld_reconnects` against this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes consumer error-handling semantics by re-raising exceptions after logging, which can alter runtime behavior/reconnect loops for malformed messages. Adds stricter payload validation that may now reject previously tolerated non-dict payloads.
> 
> **Overview**
> Prevents malformed/non-JSON messages from failing later with unclear errors by validating `WazoEventMixin._unmarshal` input and raising a clear `ValueError` when the payload is not a dict.
> 
> Stops silently swallowing consumer processing failures by re-raising exceptions in `ConsumerMixin.__on_message_received` (while still acking in `finally`), and adds integration tests covering `_unmarshal` accept/reject behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2c62c84dd114a45465dcabec9aa7f1e0f51d9d03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->