### PR TITLE
auth: add tenant-scoped ExternalAuth lifecycle events

### DIFF
--- a/wazo_bus/resources/auth/events.py
+++ b/wazo_bus/resources/auth/events.py
@@ -1,4 +1,4 @@
-# Copyright 2017-2025 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2017-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from ..common.event import TenantEvent, UserEvent
@@ -32,6 +32,57 @@ class TenantDeletedEvent(TenantEvent):
 
     def __init__(self, tenant_uuid: UUIDStr):
         content = {'uuid': tenant_uuid}
+        super().__init__(content, tenant_uuid)
+
+
+class ExternalAuthAddedEvent(TenantEvent):
+    service = 'auth'
+    name = 'auth_external_auth_added'
+    routing_key_fmt = 'auth.tenants.{tenant_uuid}.external.{external_auth_name}.created'
+
+    def __init__(
+        self,
+        external_auth_name: str,
+        tenant_uuid: UUIDStr,
+    ):
+        content = {
+            'uuid': tenant_uuid,
+            'external_auth_name': external_auth_name,
+        }
+        super().__init__(content, tenant_uuid)
+
+
+class ExternalAuthUpdatedEvent(TenantEvent):
+    service = 'auth'
+    name = 'auth_external_auth_updated'
+    routing_key_fmt = 'auth.tenants.{tenant_uuid}.external.{external_auth_name}.updated'
+
+    def __init__(
+        self,
+        external_auth_name: str,
+        tenant_uuid: UUIDStr,
+    ):
+        content = {
+            'uuid': tenant_uuid,
+            'external_auth_name': external_auth_name,
+        }
+        super().__init__(content, tenant_uuid)
+
+
+class ExternalAuthDeletedEvent(TenantEvent):
+    service = 'auth'
+    name = 'auth_external_auth_deleted'
+    routing_key_fmt = 'auth.tenants.{tenant_uuid}.external.{external_auth_name}.deleted'
+
+    def __init__(
+        self,
+        external_auth_name: str,
+        tenant_uuid: UUIDStr,
+    ):
+        content = {
+            'uuid': tenant_uuid,
+            'external_auth_name': external_auth_name,
+        }
         super().__init__(content, tenant_uuid)
 
 


### PR DESCRIPTION
## Summary

- Add `ExternalAuthAddedEvent`, `ExternalAuthUpdatedEvent` and `ExternalAuthDeletedEvent` for tenant-level external_auth config changes
- Events extend `TenantEvent` (no `user_uuid`) and use routing key `auth.tenants.{tenant_uuid}.external.{external_auth_name}.{created|updated|deleted}`
- Payload includes `uuid` (the tenant UUID, since `wazo_bus.Consumer` strips headers from callbacks) and `external_auth_name`, matching the convention used by `TenantUpdatedEvent` / `TenantDeletedEvent`

## Test plan
- [ ] Event classes import and instantiate cleanly
- [ ] Routing key and headers match the documented format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: purely additive event classes and routing keys with no changes to existing event behavior or data handling.
> 
> **Overview**
> Introduces tenant-level `ExternalAuthAddedEvent`, `ExternalAuthUpdatedEvent`, and `ExternalAuthDeletedEvent` to publish external-auth configuration lifecycle changes.
> 
> Each event extends `TenantEvent`, uses routing keys like `auth.tenants.{tenant_uuid}.external.{external_auth_name}.{created|updated|deleted}`, and includes `uuid` (tenant UUID) plus `external_auth_name` in the payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 688a5d631ac3e13b321fdb3b9490334f825ba945. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->