### PR TITLE
chatd: drop extra from UserIdentityDict

### DIFF
--- a/wazo_bus/resources/chatd/types.py
+++ b/wazo_bus/resources/chatd/types.py
@@ -21,7 +21,6 @@ class UserIdentityDict(TypedDict, total=False):
     backend: str
     type: str
     identity: str
-    extra: dict[str, str]
 
 
 class LinePresenceDict(TypedDict, total=False):


### PR DESCRIPTION
## Summary

- The `extra` field on user identities is admin-only metadata. It is intentionally not published on `UserIdentity*` bus events because those events route to the target user's websocket via `UserEvent` — exposing `extra` there would leak admin metadata to the end user.
- The TypedDict was declaring a field the producer (wazo-chatd) never emits. Dropping `extra` aligns the contract with the actual payload.

Producer-side change in chatd: https://github.com/wazo-platform/wazo-chatd/pull/198 (commit \`f50493d\`) reuses \`user_identity_schema\` so the bus payload matches this TypedDict exactly: \`{uuid, backend, type, identity}\`.

## Test plan
- [x] mypy and existing wazo-bus checks pass (no tests for chatd TypedDicts in this repo)
- [x] Producer (wazo-chatd) verified: 372 unit + 33 integration tests pass with the new payload shape

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a typing-contract change only, aligning the declared bus payload shape with what is actually emitted and avoiding exposure of admin-only metadata.
> 
> **Overview**
> Drops the `extra` field from `UserIdentityDict` in `wazo_bus/resources/chatd/types.py`, tightening the declared chatd bus-event payload to `{uuid, backend, type, identity}`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2332e9cd190038e0203be1a2faeb996ad814611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->