### PR TITLE
[ITEM-407] feat(auth): add UserDeletedEvent

### DIFF
--- a/wazo_bus/resources/auth/events.py
+++ b/wazo_bus/resources/auth/events.py
@@ -248,3 +248,13 @@ class SessionExpireSoonEvent(UserEvent):
         }
         super().__init__(content, tenant_uuid, user_uuid)
         self.session_uuid = str(session_uuid)
+
+
+class UserDeletedEvent(UserEvent):
+    service = 'auth'
+    name = 'auth_user_deleted'
+    routing_key_fmt = 'auth.users.{user_uuid}.deleted'
+
+    def __init__(self, tenant_uuid: UUIDStr, user_uuid: UUIDStr):
+        content = {'uuid': user_uuid, 'tenant_uuid': tenant_uuid}
+        super().__init__(content, tenant_uuid, user_uuid)


### PR DESCRIPTION
## Summary of the changes

- Add `UserDeletedEvent` (`auth_user_deleted`) to the auth bus resources

This is a user-scoped event (extends `UserEvent`), so it is delivered over the websocket only to the deleted user's own session via the `user_uuid:{uuid}` header. It lets mobile/web apps detect that the current session user was deleted and log out gracefully.

- name: `auth_user_deleted`
- routing_key: `auth.users.{user_uuid}.deleted`
- content: `{uuid, tenant_uuid}`

Consumed by wazo-auth (separate PR) which publishes it on user deletion.

## How to test

- `tox -e py311` (and `tox -e linters`)
- Construct the event and verify `routing_key == auth.users.{user_uuid}.deleted` and the headers contain `user_uuid:{uuid}: True`